### PR TITLE
fix(github/workflows): use latest commit for web3.storage action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Extract artifact
         run: tar -xvf public.tar
       - name: Add public CAR file
-        uses: web3-storage/add-to-web3@v1
+        uses: web3-storage/add-to-web3@77b645f58a5ec593d5ab23666fee1537331b7858
         id: web3
         with:
           web3_token: ${{ secrets.WEB3_STORAGE_TOKEN }}


### PR DESCRIPTION
This patch uses the lastet commit at the time for web3.storage action in order
to support hidden files.